### PR TITLE
Github Actions: Migration CI Inline

### DIFF
--- a/.github/workflows/migrate.yml
+++ b/.github/workflows/migrate.yml
@@ -6,5 +6,28 @@ on:
 
 jobs:
   migrate:
-    name: Migrate Debug Variant
-    uses: ./.github/workflows/migrate_action.yml
+    runs-on: ubuntu-latest
+    environment: production
+
+    env:
+      POSTGRES_URL: ${{ secrets.POSTGRES_URL }}
+      POSTGRES_USER: ${{ secrets.POSTGRES_USER }}
+      POSTGRES_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
+      POSTGRES_HOST: ${{ secrets.POSTGRES_HOST }}
+      POSTGRES_DATABASE: ${{ secrets.POSTGRES_DATABASE }}
+      JWT_SECRET: ${{ secrets.JWT_SECRET }}
+
+    strategy:
+      matrix:
+        node-version: [20.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: "yarn"
+      - run: yarn
+      - run: yarn migrate:push


### PR DESCRIPTION
Removed the Worflow Action in favor for an inline Migration since it isn't shared anyway.